### PR TITLE
volume .bash_history only

### DIFF
--- a/consai2r2.sh
+++ b/consai2r2.sh
@@ -38,7 +38,7 @@ docker run ${OPT}    \
     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
     --gpus=all \
     --name=${cname} \
-    --volume="${PROGRAM_DIR:-$DEFAULT_USER_DIR}/root:/root" \
+    --volume="${PROGRAM_DIR:-$DEFAULT_USER_DIR}/root/.bash_history:/root/.bash_history" \
     --volume="${PROGRAM_DIR:-$DEFAULT_USER_DIR}:/userdir" \
     -w="/userdir" \
     ${iname} ${EXE}


### PR DESCRIPTION
rootディレクトリそのものをvolumeにするとls='ls color=auto'のaliasなどが死んでしまうので.bash_historyのみにした